### PR TITLE
Fix drag and drop functionality for cards to engine slots

### DIFF
--- a/elastic-app/app/src/scenes/core/effects/activation_logic.gd
+++ b/elastic-app/app/src/scenes/core/effects/activation_logic.gd
@@ -5,16 +5,19 @@ static func activate(source: Entity, target: Entity) -> bool:
 	var source_type = get_type(source)
 	var target_type = get_type(target)
 	
+	# Handle card being dropped on battleground (which contains the engine slots)
+	# Since there are no instinct effects anymore, cards need to be dropped on ENGINE_BUTTON entities
 	if source_type == Entity.EntityType.CARD and target_type == Entity.EntityType.BATTLEGROUND:
 		var card: Card = source as Card
 		
 		if not card.cost.satisfy(source, target):
 			return false
 		
-		if card.has_instinct_effect():
-			return activate_instinct(card)
-		else:
-			return false
+		# All cards must be slotted now - no instinct effects exist
+		# This shouldn't happen but provide a clear error message
+		push_warning("Card dropped on battleground instead of engine slot: " + card.display_name)
+		push_warning("Cards must be dropped on specific engine slots to be played")
+		return false
 	elif source_type == Entity.EntityType.CARD and target_type == Entity.EntityType.ENGINE_BUTTON:
 		var card: Card = source as Card
 		var button: EngineButtonEntity = target as EngineButtonEntity

--- a/elastic-app/app/src/scenes/ui/battleground/ui_battleground.gd
+++ b/elastic-app/app/src/scenes/ui/battleground/ui_battleground.gd
@@ -5,9 +5,13 @@ var next_slot: int = 0
 
 func _ready():
 	GlobalSignals.ui_started_game.connect(__on_start_game)
+	# Set mouse filter to ignore so engine slots can receive mouse events
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
 	
 func __on_start_game():
-	set_entity_data(BattlegroundEntity.BattlegroundEntityBuilder.new().build())
+	# Don't create a battleground entity since cards should target engine slots directly
+	# set_entity_data(BattlegroundEntity.BattlegroundEntityBuilder.new().build())
+	
 	for i in range(15*7):
 		var engine_slot_scene: PackedScene = preload("res://src/scenes/ui/entities/engine/ui_engine_slot.tscn")
 		var slot_instance: EngineSlot = engine_slot_scene.instantiate()


### PR DESCRIPTION
## Summary
- Fixed drag and drop not working when trying to place cards on the board
- Cards were being blocked by the battleground container instead of reaching engine slots

## Changes
1. **Updated activation logic** - Removed instinct effect handling (no longer exists) and added clear warning messages
2. **Fixed mouse event blocking** - Set UiBattleground to MOUSE_FILTER_IGNORE so engine slots can receive events
3. **Disabled battleground entity** - Commented out entity creation to prevent hover conflicts

## Test plan
- [ ] Launch the game
- [ ] Draw cards into hand
- [ ] Drag a card from hand to an engine slot on the board
- [ ] Verify the card is successfully placed in the slot
- [ ] Verify no console errors appear

Fixes the issue: "I can't drag and drop the card to the board."